### PR TITLE
feat: add Send method for different virtual classes

### DIFF
--- a/docs/VirtualGamepad.md
+++ b/docs/VirtualGamepad.md
@@ -24,6 +24,7 @@ The `VirtualGamepad` interface defines the core functionalities of a virtual gam
 | **MoveRightStick**  | Moves the Right analog stick to the specified X and Y coordinates (values between -1 and 1). |
 | **MoveRightStickX** | Moves the right analog stick on the X-axis.                                                  |
 | **MoveRightStickY** | Moves the right analog stick on the Y-axis.                                                  |
+| **Send**            | Sends a raw input event of the specified type, code, and value.                              |
 
 #### **Standardized Gamepad Input Handling**
 
@@ -196,6 +197,8 @@ func main() {
     g.MoveLeftStick(0.5, -0.5)
     
     g.MoveRightStick(-1.0, 1.0)
+
+    g.Send(uint16(linux.EV_KEY), uint16(gamepad.ButtonA), 1)
 	
 }
 ```

--- a/docs/VirtualKeyboard.md
+++ b/docs/VirtualKeyboard.md
@@ -19,6 +19,7 @@ The `VirtualKeyboard` interface defines the core functionalities of a virtual ke
 | **ReleaseKey** | Simulates releasing a specific key.                                                  |
 | **Type**       | Simulates typing a string of characters using the virtual keyboard.                  |
 | **SetLed**     | Controls the state of a keyboard LED (e.g., Caps Lock or Num Lock).                  |
+| **Send**       | Sends a raw input event of the specified type, code, and value.                      |
 
 
 ####  **Keyboard Layout Detection in `Type`**

--- a/docs/VirtualMouse.md
+++ b/docs/VirtualMouse.md
@@ -34,6 +34,7 @@ The `VirtualMouse` interface defines the core functionalities of a virtual mouse
 | **DoubleClickRight** | Convenience method to simulate a double left click.                                              |
 | **DoubleClickRight** | Convenience method to simulate a double right click.                                             |
 | **DoubleClickMiddle**| Convenience method to simulate a double middle click.                                            |
+| **Send**             | Sends a raw input event of the specified type, code, and value.                                  |
 
 
 ##### **Custom Configuration**

--- a/docs/VirtualTouchpad.md
+++ b/docs/VirtualTouchpad.md
@@ -33,6 +33,7 @@ _Pressure is between 0 and 1_
 | **ClickRight**       | Convenience method to simulate a single right click.                                                                                                                                                   |
 | **DoubleClickLeft**  | Convenience method to simulate a double left click.                                                                                                                                                    |
 | **DoubleClickRight** | Convenience method to simulate a double right click.                                                                                                                                                   |
+| **Send**             | Sends a raw input event of the specified type, code, and value.                                                                                                                                        |
 
 
 #### **Touchpad Handling**

--- a/gamepad/gamepad.go
+++ b/gamepad/gamepad.go
@@ -2,6 +2,7 @@ package gamepad
 
 import (
 	"fmt"
+
 	virtual_device "github.com/jbdemonte/virtual-device"
 	"github.com/jbdemonte/virtual-device/linux"
 )
@@ -20,6 +21,8 @@ type VirtualGamepad interface {
 	MoveRightStick(x, y float32)
 	MoveRightStickX(x float32)
 	MoveRightStickY(y float32)
+
+	Send(evType, code uint16, value int32)
 }
 
 type VirtualGamepadFactory interface {
@@ -264,4 +267,8 @@ func (vg *virtualGamepad) MoveRightStickY(y float32) {
 	if vg.rightStick != nil {
 		vg.moveAxis(&vg.rightStick.Y, y)
 	}
+}
+
+func (vg *virtualGamepad) Send(evType, code uint16, value int32) {
+	vg.device.Send(evType, code, value)
 }

--- a/keyboard/keyboard.go
+++ b/keyboard/keyboard.go
@@ -2,9 +2,10 @@ package keyboard
 
 import (
 	"fmt"
+	"time"
+
 	virtual_device "github.com/jbdemonte/virtual-device"
 	"github.com/jbdemonte/virtual-device/linux"
-	"time"
 )
 
 type VirtualKeyboard interface {
@@ -18,6 +19,8 @@ type VirtualKeyboard interface {
 	SetLed(led linux.Led, state bool)
 	SendMiscEvent(event linux.MiscEvent, value int32)
 	SyncReport()
+
+	Send(evType, code uint16, value int32)
 }
 
 type VirtualKeyboardFactory interface {
@@ -181,4 +184,8 @@ func (vk *virtualKeyboard) Type(content string) {
 			fmt.Printf("Warning: Character '%c' is not mapped\n", char)
 		}
 	}
+}
+
+func (vk *virtualKeyboard) Send(evType, code uint16, value int32) {
+	vk.device.Send(evType, code, value)
 }

--- a/mouse/mouse.go
+++ b/mouse/mouse.go
@@ -1,9 +1,10 @@
 package mouse
 
 import (
+	"time"
+
 	virtual_device "github.com/jbdemonte/virtual-device"
 	"github.com/jbdemonte/virtual-device/linux"
-	"time"
 )
 
 type VirtualMouse interface {
@@ -35,6 +36,8 @@ type VirtualMouse interface {
 	DoubleClickLeft()
 	DoubleClickRight()
 	DoubleClickMiddle()
+
+	Send(evType, code uint16, value int32)
 }
 
 type VirtualMouseFactory interface {
@@ -213,4 +216,8 @@ func (vm *virtualMouse) DoubleClickRight() {
 
 func (vm *virtualMouse) DoubleClickMiddle() {
 	vm.DoubleClick(linux.BTN_MIDDLE)
+}
+
+func (vm *virtualMouse) Send(evType, code uint16, value int32) {
+	vm.device.Send(evType, code, value)
 }

--- a/touchpad/touchpad.go
+++ b/touchpad/touchpad.go
@@ -1,9 +1,10 @@
 package touchpad
 
 import (
+	"time"
+
 	virtual_device "github.com/jbdemonte/virtual-device"
 	"github.com/jbdemonte/virtual-device/linux"
-	"time"
 )
 
 // https://www.kernel.org/doc/Documentation/input/multi-touch-protocol.txt
@@ -33,6 +34,8 @@ type VirtualTouchpad interface {
 
 	DoubleClickLeft()
 	DoubleClickRight()
+
+	Send(evType, code uint16, value int32)
 }
 
 type VirtualTouchpadFactory interface {
@@ -293,4 +296,8 @@ func (vt *virtualTouchpad) DoubleClickLeft() {
 
 func (vt *virtualTouchpad) DoubleClickRight() {
 	vt.DoubleClick(linux.BTN_RIGHT)
+}
+
+func (vt *virtualTouchpad) Send(evType, code uint16, value int32) {
+	vt.device.Send(evType, code, value)
 }


### PR DESCRIPTION
Add Send(evType, code, value) to the VirtualGamepad interface and its implementation. This exposes raw event injection through the underlying virtual_device, enabling low-level input control for advanced use cases.